### PR TITLE
Use CIColorCubeWithColorSpace to define device's RGB color space

### DIFF
--- a/InstaCubeExample/InstaCube/InstaCubeGenerator.m
+++ b/InstaCubeExample/InstaCube/InstaCubeGenerator.m
@@ -31,11 +31,16 @@
     CGImageRef keyCgImage = keyImage.CGImage;
     int sizeOfCube = floor(CGImageGetWidth(keyCgImage));
     NSData *colorCubeNSData = [self colorCubeDataForCGImageRef:keyCgImage];
-    
-    CIFilter *instaCube = [CIFilter filterWithName:@"CIColorCube"
-                               withInputParameters:@{@"inputCubeDimension" : @(sizeOfCube),
-                                                     @"inputCubeData" : colorCubeNSData}];
-    
+  
+    CGColorSpaceRef colorSpace;
+    colorSpace = CGColorSpaceCreateDeviceRGB();
+  
+    CIFilter *instaCube = [CIFilter filterWithName:@"CIColorCubeWithColorSpace"
+                             withInputParameters:@{@"inputCubeDimension" : @(sizeOfCube),
+                                                   @"inputCubeData" : colorCubeNSData,
+                                                   @"inputColorSpace" : (__bridge id) colorSpace}];
+  
+    CGColorSpaceRelease(colorSpace);
     return instaCube;
 }
 


### PR DESCRIPTION
## Description

CIColorCube uses kCGColorSpaceGenericRGBLinear as the color space. This isn't the case for at least the latest iOS 9.1 version. What happens is that the lookup image conversion to CIColorCube will lose a significant amount of colors on iOS 9.1.
## Solution

Using CIColorCubeWithColorSpace, this code now defines the color space for the Color Cube to use, which we simply get with CGColorSpaceCreateDeviceRGB()
